### PR TITLE
Support webservers other then Apache HTTPD

### DIFF
--- a/app/api/backup.php
+++ b/app/api/backup.php
@@ -17,7 +17,7 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-include "../../pswd.php";
+include __DIR__ ."/../../pswd.php";
 $host = $_SERVER['HTTP_HOST'];
 $failoverHash = "Qma25ZSNbp9AdjrPczjzKYm7zUAdcu9jQZJXbsPiifW79M";
 

--- a/app/api/redirectRandomly.php
+++ b/app/api/redirectRandomly.php
@@ -17,7 +17,7 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-include "../../pswd.php";
+include __DIR__ ."/../../pswd.php";
 $host = $_SERVER['HTTP_HOST'];
 $hash = "Qma25ZSNbp9AdjrPczjzKYm7zUAdcu9jQZJXbsPiifW79M";
 

--- a/app/api/vote.php
+++ b/app/api/vote.php
@@ -17,7 +17,7 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-include "../../pswd.php";
+include __DIR__ ."/../../pswd.php";
 if ( !isset($_GET['id']) or !isset($_GET['type']) ) {
 	exit("wrong params");
 } else {

--- a/app/index.php
+++ b/app/index.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-include "class/ipfs.class.php";
+include __DIR__ ."/class/ipfs.class.php";
 
 $ipfs = new IPFS("localhost");
 

--- a/app/pages/browse.php
+++ b/app/pages/browse.php
@@ -19,8 +19,8 @@
 */
 error_reporting(0);
 
-include "../../pswd.php";
-include "../class/ipfs.class.php";
+include __DIR__ ."/../../pswd.php";
+include __DIR__ ."/../class/ipfs.class.php";
 
 
 $db = new PDO('mysql:host=localhost;dbname=hashes;charset=utf8', $db_user, $db_pswd, array(

--- a/app/pages/preview.php
+++ b/app/pages/preview.php
@@ -18,8 +18,8 @@
 */
 error_reporting(0);
 
-include "../../pswd.php";
-include "../class/ipfs.class.php";
+include __DIR__ ."/../../pswd.php";
+include __DIR__ ."/../class/ipfs.class.php";
 
 if( !isset($_GET['hash']) ) {
 	$hash = "QmYqA8GiZ4MCeyJkERReLwGRnjSdQBx5SzjvMgiNwQZfx6";

--- a/app/picture.php
+++ b/app/picture.php
@@ -17,8 +17,8 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-include "class/ipfs.class.php";
-include "../pswd.php";
+include __DIR__ ."/class/ipfs.class.php";
+include __DIR__ ."/../pswd.php";
 
 $db = new PDO('mysql:host=localhost;dbname=hashes;charset=utf8', $db_user, $db_pswd, array(
     PDO::ATTR_PERSISTENT => true

--- a/app/router.php
+++ b/app/router.php
@@ -1,0 +1,50 @@
+<?php
+/*
+    Simple router, .htaccess interpreter for webservers other then Apache HTTPD
+    Copyright (C) 2016 Sjon Hortensius
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+$path = ltrim($_SERVER['DOCUMENT_URI'], '/');
+
+foreach (file('.htaccess', FILE_IGNORE_NEW_LINES) as $line) {
+	if ( !preg_match('~^RewriteRule (?P<match>\^.*) (?P<page>.*?)(?P<params>\?.*)?$~', $line, $rule) )
+		continue; # not a rewrite rule
+
+	if ( !preg_match('~'. $rule['match'] .'~', $path, $parts) )
+		continue; # no match
+
+	// Convert numeric array into ['$1' => '25'], suitable for str_replace
+	$replace = [];
+	foreach ($parts as $idx => $part)
+		$replace[ '$'. $idx ] = $part;
+
+	if ( isset($rule['params']) ) {
+		parse_str(ltrim($rule['params'], '?'), $params);
+		foreach ($params as $key => $value) {
+			if (false !== strpos($value, '$'))
+				$value = str_replace(array_keys($replace), $replace, $value);
+
+			$_GET[$key] = $value;
+		}
+	}
+
+	if (!is_readable($rule['page']) || __DIR__ !== substr(dirname(__DIR__ .'/'. $rule['page']), 0, strlen(__DIR__)))
+		die('it seems we escaped our docroot, this shouldn\'t happen');
+
+	return require($rule['page']);
+}
+
+require('index.php');

--- a/app/upload.php
+++ b/app/upload.php
@@ -18,8 +18,8 @@
 */
 error_reporting(0);
 
-include "../pswd.php";
-include "class/ipfs.class.php";
+include __DIR__ ."/../pswd.php";
+include __DIR__ ."/class/ipfs.class.php";
 
 $ipfs = new IPFS("localhost", "8080", "5001"); 
 


### PR DESCRIPTION
Done by implementing a .htaccess interpreter. This doesn't chdir like Apache, so update all include() statements as well.

Running ipfspics with nginx can be completed by configuring nginx roughly like this:

```
server
{
        listen      80;
        server_name SUBDOMAIN;
        root        /srv/http/SUBDOMAIN/app;

        location /
        {
                include         fastcgi_params;
                fastcgi_param   SCRIPT_FILENAME $document_root/router.php;
                fastcgi_pass    unix:/var/run/php-fpm/php-fpm.sock;
        }
}
```
